### PR TITLE
Add MonadTrans Decoder instance

### DIFF
--- a/src/Waargonaut/Decode/Types.hs
+++ b/src/Waargonaut/Decode/Types.hs
@@ -86,6 +86,9 @@ instance Monad f => MonadError DecodeError (Decoder f) where
   catchError d handle = Decoder $ \p c ->
     catchError (runDecoder d p c) (\e -> runDecoder (handle e) p c)
 
+instance MonadTrans Decoder where
+  lift fa = Decoder (\ _ _ -> lift fa)
+
 instance MFunctor Decoder where
   hoist nat (Decoder pjdr) = Decoder (\p -> hoist nat . pjdr p)
 


### PR DESCRIPTION
This allows use of side-effects from the monad `m` in an expression of type `Decoder m a`.    

To illustrate: I'm writing a program that needs to create unique identifiers for certain objects; these are not stored in the JSON file. So the encoders dismiss them, and the decoders generate new unique identifiers using a monadic side effect:

```haskell

data Document = Document
  { documentName   :: !Text
  , documentData   :: !SomeData
  , documentUnique :: !Unique
  }

class MonadUnique m where
  freshUnique :: m Unique

encodeDocument :: Applicative m => Encoder m Document
encodeDocument = Encoder.mapLikeObj \ ( Document { .. } ) ->
    Encoder.atKey' "name" Encoder.text          documentName
  . Encoder.atKey' "data" myDocumentDataEncoder documentData

decodeDocument :: MonadUnique m => Decoder m Document
decodeDocument = do
  documentName   <- Decoder.atKey "name" Decoder.text
  documentData   <- Decoder.atKey "data" myDocumentDataDecoder
  documentUnique <- lift freshUnique
  pure ( Document { .. } )
```
